### PR TITLE
fix: targetPostId 미전달 문제 수정

### DIFF
--- a/components/calendar/CalendarFormDialog.tsx
+++ b/components/calendar/CalendarFormDialog.tsx
@@ -57,7 +57,7 @@ export function CalendarFormDialog({
     if (event) {
       setTitle(event.title)
       setType(event.type)
-      setTargetPostId(event.targetPostId != null ? String(event.targetPostId) : "")
+      setTargetPostId(event.targetPostId ?? "")
       
       // ISO 문자열에서 날짜/시간 직접 추출 (타임존 변환 방지)
       const startParts = event.start.split("T")
@@ -71,6 +71,7 @@ export function CalendarFormDialog({
       // 달력에서 날짜 클릭 시 초기값 설정
       setTitle("")
       setType("ACADEMIC")
+      setTargetPostId("")
       
       const startYear = initialDates.start.getFullYear()
       const startMonth = String(initialDates.start.getMonth() + 1).padStart(2, '0')
@@ -132,7 +133,7 @@ export function CalendarFormDialog({
       type,
       start: start.toISOString(),
       end: end.toISOString(),
-      ...(targetPostId.trim() !== "" && { targetPostId: Number(targetPostId) }),
+      ...(targetPostId.trim() !== "" && { targetPostId: targetPostId.trim() }),
     }
 
     onSubmit(data)
@@ -219,8 +220,7 @@ export function CalendarFormDialog({
           <Label htmlFor="targetPostId">연결 게시물 ID</Label>
           <Input
             id="targetPostId"
-            type="number"
-            min={1}
+            type="text"
             value={targetPostId}
             onChange={(e) => setTargetPostId(e.target.value)}
             placeholder="게시물 ID (선택사항)"

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -12,7 +12,7 @@ export interface CalendarEvent {
   type: CalendarType
   start: string
   end: string
-  targetPostId?: number
+  targetPostId?: string
 }
 
 export interface CalendarListParams {
@@ -31,7 +31,7 @@ export interface CreateCalendarEventRequest {
   type: CalendarType
   start: string
   end: string
-  targetPostId?: number
+  targetPostId?: string
 }
 
 export interface UpdateCalendarEventRequest {
@@ -39,5 +39,5 @@ export interface UpdateCalendarEventRequest {
   type: CalendarType
   start: string
   end: string
-  targetPostId?: number
+  targetPostId?: string
 }


### PR DESCRIPTION
targetPostId가 int로 받고 있어서 uuid의 "-"가 포함되면 빈값이 되고 이 때문에 미전달되는 문제를 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 달력 이벤트 양식에서 대상 게시물 ID 필드의 입력 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->