### PR TITLE
feat: 게시판 공지글 마스킹 설정 추가

### DIFF
--- a/app/content/boards/[boardId]/edit/page.tsx
+++ b/app/content/boards/[boardId]/edit/page.tsx
@@ -40,6 +40,9 @@ import type {
 import { useState, useEffect } from "react"
 import { Trash2, Pencil } from "lucide-react"
 import { BoardAdminEditModal } from "@/components/content/BoardAdminEditModal"
+import { BoardOfficialProfileFields } from "@/components/content/BoardOfficialProfileFields"
+import { uploadStorageFileV2 } from "@/lib/api/v2/storage"
+import { toast } from "sonner"
 
 export default function BoardEditPage() {
   const params = useParams()
@@ -56,6 +59,9 @@ export default function BoardEditPage() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deleteConfirmText, setDeleteConfirmText] = useState("")
   const [adminModalOpen, setAdminModalOpen] = useState(false)
+  const [officialProfileFile, setOfficialProfileFile] = useState<File | null>(null)
+  const [officialProfilePreviewUrl, setOfficialProfilePreviewUrl] = useState<string | null>(null)
+  const [isUploadingOfficialProfile, setIsUploadingOfficialProfile] = useState(false)
 
   const DELETE_CONFIRM_PHRASE = "삭제하겠습니다"
 
@@ -79,6 +85,8 @@ export default function BoardEditPage() {
       writeScope,
       isNotice: board.isNotice,
       visibility,
+      officialNickname: board.officialNickname ?? null,
+      officialProfileImageUrl: board.officialProfileImageUrl ?? null,
     })
     setAdmins(board.admins ?? [])
     setFormSynced(true)
@@ -87,16 +95,56 @@ export default function BoardEditPage() {
   // boardId가 바뀌면 동기화 플래그 리셋 (다른 게시판으로 이동 시)
   useEffect(() => {
     setFormSynced(false)
+    setOfficialProfileFile(null)
   }, [boardId])
 
-  const handleSubmit = (e: React.FormEvent) => {
+  useEffect(() => {
+    if (!officialProfileFile) {
+      setOfficialProfilePreviewUrl(null)
+      return
+    }
+    const objectUrl = URL.createObjectURL(officialProfileFile)
+    setOfficialProfilePreviewUrl(objectUrl)
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [officialProfileFile])
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const adminUserIds = admins.map((a) => a.id)
-    updateBoardV2.mutate({
-      ...formData,
-      boardId,
-      adminUserIds,
-    })
+    if (isUploadingOfficialProfile || updateBoardV2.isPending) return
+
+    setIsUploadingOfficialProfile(true)
+    try {
+      const uploadedImageUrl = officialProfileFile
+        ? await uploadStorageFileV2(officialProfileFile)
+        : formData.officialProfileImageUrl
+      const adminUserIds = admins.map((a) => a.id)
+
+      updateBoardV2.mutate(
+        {
+          ...formData,
+          boardId,
+          officialNickname: formData.officialNickname?.trim() || null,
+          officialProfileImageUrl: uploadedImageUrl || null,
+          adminUserIds,
+        },
+        {
+          onSuccess: () => {
+            setFormData((prev) => ({
+              ...prev,
+              officialNickname: prev.officialNickname?.trim() || null,
+              officialProfileImageUrl: uploadedImageUrl || null,
+            }))
+            setOfficialProfileFile(null)
+          },
+          onSettled: () => setIsUploadingOfficialProfile(false),
+        }
+      )
+    } catch (error) {
+      setIsUploadingOfficialProfile(false)
+      toast.error(
+        error instanceof Error ? error.message : "프로필 이미지 업로드에 실패했습니다."
+      )
+    }
   }
 
   if (isLoading) {
@@ -228,6 +276,17 @@ export default function BoardEditPage() {
                 placeholder="게시판 설명을 입력하세요"
               />
             </div>
+            <BoardOfficialProfileFields
+              inputIdPrefix="edit"
+              officialNickname={formData.officialNickname ?? ""}
+              previewUrl={officialProfilePreviewUrl ?? formData.officialProfileImageUrl ?? null}
+              selectedFileName={officialProfileFile?.name}
+              disabled={updateBoardV2.isPending || isUploadingOfficialProfile}
+              onNicknameChange={(officialNickname) =>
+                setFormData({ ...formData, officialNickname })
+              }
+              onFileChange={setOfficialProfileFile}
+            />
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-2">
                 <Label>관리자</Label>
@@ -348,8 +407,8 @@ export default function BoardEditPage() {
               >
                 취소
               </Button>
-              <Button type="submit" disabled={updateBoardV2.isPending}>
-                {updateBoardV2.isPending ? "저장 중..." : "수정"}
+              <Button type="submit" disabled={updateBoardV2.isPending || isUploadingOfficialProfile}>
+                {updateBoardV2.isPending || isUploadingOfficialProfile ? "저장 중..." : "수정"}
               </Button>
             </div>
           </CardContent>

--- a/app/content/boards/page.tsx
+++ b/app/content/boards/page.tsx
@@ -55,7 +55,10 @@ import {
   VISIBILITIES,
 } from "@/lib/constants/board-v2-form"
 import { BoardAdminEditModal } from "@/components/content/BoardAdminEditModal"
+import { BoardOfficialProfileFields } from "@/components/content/BoardOfficialProfileFields"
 import { BoardFilter, type BoardFilterValues } from "@/components/content/BoardFilter"
+import { uploadStorageFileV2 } from "@/lib/api/v2/storage"
+import { toast } from "sonner"
 
 /** displayOrder 기준 정렬 */
 function sortByDisplayOrder(items: BoardListItemV2[]): BoardListItemV2[] {
@@ -138,10 +141,28 @@ export default function BoardsPage() {
 
   const [formData, setFormData] = useState(defaultV2Form)
   const [createAdmins, setCreateAdmins] = useState<BoardAdminInfo[]>([])
+  const [officialProfileFile, setOfficialProfileFile] = useState<File | null>(null)
+  const [officialProfilePreviewUrl, setOfficialProfilePreviewUrl] = useState<string | null>(null)
+  const [isUploadingOfficialProfile, setIsUploadingOfficialProfile] = useState(false)
 
-  const handleCreate = () => {
+  useEffect(() => {
+    if (!officialProfileFile) {
+      setOfficialProfilePreviewUrl(null)
+      return
+    }
+    const objectUrl = URL.createObjectURL(officialProfileFile)
+    setOfficialProfilePreviewUrl(objectUrl)
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [officialProfileFile])
+
+  const resetCreateForm = () => {
     setFormData(defaultV2Form)
     setCreateAdmins([])
+    setOfficialProfileFile(null)
+  }
+
+  const handleCreate = () => {
+    resetCreateForm()
     setCreateDialogOpen(true)
   }
 
@@ -181,18 +202,37 @@ export default function BoardsPage() {
     setOrderBoardIds(next)
   }
 
-  const handleCreateSubmit = () => {
-    const adminUserIds = createAdmins.map((a) => a.id)
-    createBoardV2.mutate(
-      { ...formData, adminUserIds },
-      {
-        onSuccess: () => {
-          setCreateDialogOpen(false)
-          setFormData(defaultV2Form)
-          setCreateAdmins([])
+  const handleCreateSubmit = async () => {
+    if (isUploadingOfficialProfile || createBoardV2.isPending) return
+
+    setIsUploadingOfficialProfile(true)
+    try {
+      const uploadedImageUrl = officialProfileFile
+        ? await uploadStorageFileV2(officialProfileFile)
+        : formData.officialProfileImageUrl
+      const adminUserIds = createAdmins.map((a) => a.id)
+
+      createBoardV2.mutate(
+        {
+          ...formData,
+          officialNickname: formData.officialNickname?.trim() || null,
+          officialProfileImageUrl: uploadedImageUrl || null,
+          adminUserIds,
         },
-      }
-    )
+        {
+          onSuccess: () => {
+            setCreateDialogOpen(false)
+            resetCreateForm()
+          },
+          onSettled: () => setIsUploadingOfficialProfile(false),
+        }
+      )
+    } catch (error) {
+      setIsUploadingOfficialProfile(false)
+      toast.error(
+        error instanceof Error ? error.message : "프로필 이미지 업로드에 실패했습니다."
+      )
+    }
   }
 
   return (
@@ -359,7 +399,7 @@ export default function BoardsPage() {
         description="새로운 게시판을 생성합니다."
         confirmText="생성"
         onConfirm={handleCreateSubmit}
-        isLoading={createBoardV2.isPending}
+        isLoading={createBoardV2.isPending || isUploadingOfficialProfile}
       >
         <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
           <div className="space-y-2">
@@ -380,6 +420,17 @@ export default function BoardsPage() {
               placeholder="게시판 설명을 입력하세요"
             />
           </div>
+          <BoardOfficialProfileFields
+            inputIdPrefix="create"
+            officialNickname={formData.officialNickname ?? ""}
+            previewUrl={officialProfilePreviewUrl ?? formData.officialProfileImageUrl ?? null}
+            selectedFileName={officialProfileFile?.name}
+            disabled={createBoardV2.isPending || isUploadingOfficialProfile}
+            onNicknameChange={(officialNickname) =>
+              setFormData({ ...formData, officialNickname })
+            }
+            onFileChange={setOfficialProfileFile}
+          />
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-2">
               <Label>관리자</Label>

--- a/components/content/BoardOfficialProfileFields.tsx
+++ b/components/content/BoardOfficialProfileFields.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface BoardOfficialProfileFieldsProps {
+  officialNickname: string
+  previewUrl: string | null
+  selectedFileName?: string
+  inputIdPrefix: string
+  disabled?: boolean
+  onNicknameChange: (value: string) => void
+  onFileChange: (file: File | null) => void
+}
+
+export function BoardOfficialProfileFields({
+  officialNickname,
+  previewUrl,
+  selectedFileName,
+  inputIdPrefix,
+  disabled = false,
+  onNicknameChange,
+  onFileChange,
+}: BoardOfficialProfileFieldsProps) {
+  const fileInputId = `${inputIdPrefix}-official-profile-image`
+
+  return (
+    <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+      <div>
+        <h3 className="text-sm font-medium">공지글 마스킹 설정</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          공지글 작성자 대신 표시할 게시판 공식 닉네임과 프로필 이미지를 설정합니다.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${inputIdPrefix}-official-nickname`}>공식 닉네임</Label>
+        <Input
+          id={`${inputIdPrefix}-official-nickname`}
+          value={officialNickname}
+          onChange={(e) => onNicknameChange(e.target.value)}
+          placeholder="예: 소프트웨어학부 학생회"
+          disabled={disabled}
+        />
+        <p className="text-xs text-muted-foreground">
+          미입력 시 백엔드 기본값인 “게시판 관리자”가 사용됩니다.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={fileInputId}>공식 프로필 이미지</Label>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border bg-background text-xs text-muted-foreground">
+            {previewUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={previewUrl}
+                alt="공식 프로필 이미지 미리보기"
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span>Preview</span>
+            )}
+          </div>
+          <div className="flex-1 space-y-1">
+            <Input
+              id={fileInputId}
+              type="file"
+              accept="image/*"
+              onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+              disabled={disabled}
+            />
+            <p className="text-xs text-muted-foreground">
+              {selectedFileName
+                ? `선택된 파일: ${selectedFileName}`
+                : "새 이미지를 선택하면 저장 전에 먼저 업로드됩니다."}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/api/v2/storage.ts
+++ b/lib/api/v2/storage.ts
@@ -1,0 +1,50 @@
+/**
+ * v2 파일 업로드 API
+ * POST /api/v2/storage/upload
+ */
+
+import { apiV2 } from "./client"
+import { unwrapV2 } from "./response"
+import type { ApiResponse } from "@/types/api-v2"
+
+const USE_MOCK_API = process.env.NEXT_PUBLIC_USE_MOCK_API === "true"
+
+export interface StorageUploadResponse {
+  url?: string
+  imageUrl?: string
+  fileUrl?: string
+  filePath?: string
+  path?: string
+}
+
+function extractUploadedUrl(data: string | StorageUploadResponse | null | undefined): string {
+  if (typeof data === "string") return data
+  const url = data?.url ?? data?.imageUrl ?? data?.fileUrl ?? data?.filePath ?? data?.path
+  if (!url) {
+    throw new Error("업로드 응답에서 이미지 URL을 찾을 수 없습니다.")
+  }
+  return url
+}
+
+/** 이미지 파일 업로드 — multipart/form-data file 파라미터 */
+export async function uploadStorageFileV2(file: File): Promise<string> {
+  if (USE_MOCK_API) {
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    return `https://picsum.photos/seed/${encodeURIComponent(file.name)}-${file.size}/160/160`
+  }
+
+  const formData = new FormData()
+  formData.append("file", file)
+
+  const res = await apiV2.post<ApiResponse<string | StorageUploadResponse>>(
+    "/storage/upload",
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  )
+
+  return extractUploadedUrl(unwrapV2(res))
+}

--- a/lib/constants/board-v2-form.ts
+++ b/lib/constants/board-v2-form.ts
@@ -43,6 +43,8 @@ export const defaultV2Form: Omit<BoardCreateRequestV2, "boardId"> = {
   writeScope: "ONLY_ADMIN",
   isNotice: false,
   visibility: "VISIBLE",
+  officialNickname: null,
+  officialProfileImageUrl: null,
 }
 
 export function parseAdminUserIds(value: string): string[] {

--- a/lib/mock/boards-v2.ts
+++ b/lib/mock/boards-v2.ts
@@ -41,6 +41,8 @@ const createMockBoard = (
     visibility: "VISIBLE" as BoardVisibility,
     displayOrder: 0,
     admins,
+    officialNickname: null,
+    officialProfileImageUrl: null,
   }
 
   return {
@@ -64,6 +66,8 @@ const mockBoards: BoardDetailV2[] = [
     visibility: "VISIBLE",
     displayOrder: 0,
     admins: [],
+    officialNickname: "소프트웨어학부 학생회",
+    officialProfileImageUrl: "https://picsum.photos/seed/student-council/160/160",
   },
   {
     boardId: "2",
@@ -176,6 +180,8 @@ export const mockBoardsV2Api = {
         writeScope: data.writeScope,
         isNotice: data.isNotice,
         visibility: data.visibility,
+        officialNickname: data.officialNickname ?? null,
+        officialProfileImageUrl: data.officialProfileImageUrl ?? null,
         displayOrder: mockBoards.length,
       },
       admins
@@ -200,6 +206,8 @@ export const mockBoardsV2Api = {
       writeScope: data.writeScope,
       isNotice: data.isNotice,
       visibility: data.visibility,
+      officialNickname: data.officialNickname ?? null,
+      officialProfileImageUrl: data.officialProfileImageUrl ?? null,
       admins,
     }
     return mockBoards[idx]

--- a/types/board-v2.ts
+++ b/types/board-v2.ts
@@ -75,6 +75,10 @@ export interface BoardDetailV2 {
   visibility: BoardVisibility
   displayOrder: number
   admins: BoardAdminInfo[]
+  /** 공지 작성자 공식 닉네임 */
+  officialNickname?: string | null
+  /** 공지 작성자 공식 프로필 이미지 URL */
+  officialProfileImageUrl?: string | null
 }
 
 /** v2 게시판 생성/수정 요청 Body */
@@ -97,4 +101,8 @@ export interface BoardCreateRequestV2 {
   isNotice: boolean
   /** 노출 여부 (BoardVisibility) */
   visibility: BoardVisibility
+  /** 공지 작성자 공식 닉네임 */
+  officialNickname?: string | null
+  /** 공지 작성자 공식 프로필 이미지 URL */
+  officialProfileImageUrl?: string | null
 }


### PR DESCRIPTION
## 작업 내용
- 게시판 v2 타입에 `officialNickname`, `officialProfileImageUrl` 필드 추가
- `/api/v2/storage/upload` multipart 이미지 업로드 API 추가
- 게시판 생성/수정 화면에 공식 닉네임 입력 및 프로필 이미지 파일 선택/미리보기 UI 추가
- 저장 시 이미지 선업로드 후 게시판 생성/수정 요청으로 URL을 병합하는 2-step submit 처리 추가
- Mock 게시판 API에 공식 프로필 필드 반영

## 검증
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 보드 생성 및 편집 시 공식 프로필 닉네임과 이미지를 설정할 수 있는 기능 추가
  * 프로필 이미지 업로드 시 미리보기 기능 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CAUCSE/ccssaa-admin-front/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->