### PR TITLE
fix: 알림센터 모바일 스크롤 버그 수정

### DIFF
--- a/components/layout/NotificationCenter.tsx
+++ b/components/layout/NotificationCenter.tsx
@@ -73,9 +73,9 @@ export function NotificationCenter() {
           </Button>
         </DialogTrigger>
 
-        <DialogContent className="left-auto right-0 top-0 h-full max-w-md translate-x-0 translate-y-0 rounded-none border-l p-0 pr-12 sm:max-w-md">
+        <DialogContent className="left-auto right-0 top-0 h-dvh max-w-md translate-x-0 translate-y-0 overflow-hidden rounded-none border-l p-0 sm:max-w-md">
           <div className="flex h-full flex-col">
-            <DialogHeader className="border-b px-5 py-4 pr-4 text-left">
+            <DialogHeader className="shrink-0 border-b px-5 py-4 pr-4 text-left">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <DialogTitle>알림 센터</DialogTitle>
@@ -89,7 +89,7 @@ export function NotificationCenter() {
               </div>
             </DialogHeader>
 
-            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
               <section className="space-y-2">
                 <div className="text-sm font-medium">최신 알림</div>
                 {isLatestLoading ? (


### PR DESCRIPTION
- h-full → h-dvh (모바일 뷰포트 대응)
- pr-12 제거 (모바일 좁은 화면 공간 확보)
- DialogContent에 overflow-hidden 추가
- DialogHeader에 shrink-0 추가
- 스크롤 영역에 min-h-0 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 알림 센터 다이얼로그의 레이아웃이 조정되어 화면 높이에 더 잘 맞게 표시됩니다.
  * 내부 스크롤 동작이 개선되어 긴 알림 목록도 더 자연스럽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->